### PR TITLE
fix(other): patch/workflows

### DIFF
--- a/.github/workflows/AddToTriage.yml
+++ b/.github/workflows/AddToTriage.yml
@@ -12,4 +12,4 @@ jobs:
   build:
     uses: The-FireHub-Project/.github/.github/workflows/AddToProject.yml@master
     secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/SemanticPullRequest.yml
+++ b/.github/workflows/SemanticPullRequest.yml
@@ -10,4 +10,4 @@ jobs:
   build:
     uses: The-FireHub-Project/.github/.github/workflows/SemanticPullRequest.yml@master
     secrets:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## 🐞 Bugs / Critical Issues Pull Request

<!--
PR TITLE FORMAT (REQUIRED):

<type>(<scope>): <short imperative summary>

Allowed types:
- security
- fix
- perf
- feat
- refactor
- docs
- chore
- ci
- composer

Allowed scopes:
application | domain | infrastructure | kernel | shared | support | tests | deps | other

PR semantic MUST represent the DOMINANT change.
Priority order:
security > fix > perf > feat > refactor > docs > chore > ci > composer
-->

### Related Issue

### Description
When the triage automation workflow was moved from individual repositories to the centralized .github repository (reusable workflow setup), the action actions/add-to-project@v1.0.2 started failing with:

`Could not resolve to a ProjectV2 with the number 2`

### Implementation Details
Standardized secret usage for GH_TOKEN.

### Testing
- [ ] Manual steps to reproduce a verified issue
- [ ] Unit / Integration tests added
- [ ] Tests passing locally
- [ ] Test coverage updated

### Documentation
- [ x Changelog entry added
- [ ] Examples updated if behavior changed
- [ ] Relevant docs updated

### Checklist
- [ ] Linked related issue(s)
- [x] Bug clearly described
- [x] Fix verified and tested
- [x] Code follows project style guidelines
- [x] PR is ready for review

### Risks / Impact
Low risk.

Scope limited to GitHub Actions automation layer.

### Notes
This fix aligns with FireHub’s centralized CI architecture and ensures consistent triage automation across all repositories within the organization.